### PR TITLE
Implementation of Database Structure and Models for the Pokémon League API

### DIFF
--- a/app/Models/Battle.php
+++ b/app/Models/Battle.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Battle extends Model
+{
+    use HasFactory;
+    
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'trainer1_id',
+        'trainer2_id',
+        'winner_id',
+        'date',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'date' => 'datetime',
+    ];
+
+    /**
+     * Get the trainer1 that participates in the battle.
+     */
+    public function trainer1()
+    {
+        return $this->belongsTo(Trainer::class, 'trainer1_id');
+    }
+
+    /**
+     * Get the trainer2 that participates in the battle.
+     */
+    public function trainer2()
+    {
+        return $this->belongsTo(Trainer::class, 'trainer2_id');
+    }
+
+    /**
+     * Get the winner of the battle.
+     */
+    public function winner()
+    {
+        return $this->belongsTo(Trainer::class, 'winner_id');
+    }
+}

--- a/app/Models/Pokemon.php
+++ b/app/Models/Pokemon.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Pokemon extends Model
+{
+    use HasFactory;
+    
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'type',
+        'level',
+        'stats',
+        'trainer_id',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'stats' => 'json',
+    ];
+
+    /**
+     * Get the trainer that owns the pokemon.
+     */
+    public function trainer()
+    {
+        return $this->belongsTo(Trainer::class);
+    }
+}

--- a/app/Models/Pokemon.php
+++ b/app/Models/Pokemon.php
@@ -10,6 +10,13 @@ class Pokemon extends Model
     use HasFactory;
     
     /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'pokemons';
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>
@@ -37,5 +44,26 @@ class Pokemon extends Model
     public function trainer()
     {
         return $this->belongsTo(Trainer::class);
+    }
+
+    /**
+     * Override the save method to check trainer's pokemon limit.
+     *
+     * @param array $options
+     * @return bool
+     */
+    public function save(array $options = [])
+    {
+        // If trainer_id is being changed (pokemon is being assigned to a trainer)
+        if ($this->isDirty('trainer_id') && $this->trainer_id !== null) {
+            $trainer = Trainer::find($this->trainer_id);
+            
+            // Check if trainer can add more pokemons
+            if ($trainer && !$trainer->canAddMorePokemons()) {
+                return false;
+            }
+        }
+        
+        return parent::save($options);
     }
 }

--- a/app/Models/Trainer.php
+++ b/app/Models/Trainer.php
@@ -21,6 +21,11 @@ class Trainer extends Model
     ];
 
     /**
+     * Maximum number of pokemons a trainer can have.
+     */
+    public const MAX_POKEMONS = 3;
+
+    /**
      * Get the user that owns the trainer.
      */
     public function user()
@@ -66,5 +71,33 @@ class Trainer extends Model
     public function battles()
     {
         return $this->battlesAsTrainer1->concat($this->battlesAsTrainer2);
+    }
+    
+    /**
+     * Check if the trainer can add more pokemons.
+     *
+     * @return bool
+     */
+    public function canAddMorePokemons(): bool
+    {
+        return $this->pokemons()->count() < self::MAX_POKEMONS;
+    }
+    
+    /**
+     * Add a pokemon to the trainer if possible.
+     *
+     * @param \App\Models\Pokemon $pokemon
+     * @return bool
+     */
+    public function addPokemon(Pokemon $pokemon): bool
+    {
+        if (!$this->canAddMorePokemons()) {
+            return false;
+        }
+        
+        $pokemon->trainer()->associate($this);
+        $pokemon->save();
+        
+        return true;
     }
 }

--- a/app/Models/Trainer.php
+++ b/app/Models/Trainer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Trainer extends Model
+{
+    use HasFactory;
+    
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'name',
+        'points',
+    ];
+
+    /**
+     * Get the user that owns the trainer.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the pokemons for the trainer.
+     */
+    public function pokemons()
+    {
+        return $this->hasMany(Pokemon::class);
+    }
+
+    /**
+     * Get the battles where the trainer is trainer1.
+     */
+    public function battlesAsTrainer1()
+    {
+        return $this->hasMany(Battle::class, 'trainer1_id');
+    }
+
+    /**
+     * Get the battles where the trainer is trainer2.
+     */
+    public function battlesAsTrainer2()
+    {
+        return $this->hasMany(Battle::class, 'trainer2_id');
+    }
+
+    /**
+     * Get the battles won by the trainer.
+     */
+    public function battlesWon()
+    {
+        return $this->hasMany(Battle::class, 'winner_id');
+    }
+
+    /**
+     * Get all battles where the trainer participated.
+     */
+    public function battles()
+    {
+        return $this->battlesAsTrainer1->concat($this->battlesAsTrainer2);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,20 +2,20 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Passport\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.
      *
-     * @var list<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',
@@ -26,7 +26,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var list<string>
+     * @var array<int, string>
      */
     protected $hidden = [
         'password',
@@ -34,15 +34,20 @@ class User extends Authenticatable
     ];
 
     /**
-     * Get the attributes that should be cast.
+     * The attributes that should be cast.
      *
-     * @return array<string, string>
+     * @var array<string, string>
      */
-    protected function casts(): array
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+
+    /**
+     * Get the trainer associated with the user.
+     */
+    public function trainer()
     {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-        ];
+        return $this->hasOne(Trainer::class);
     }
 }

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,202 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'permission.wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/factories/BattleFactory.php
+++ b/database/factories/BattleFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Trainer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Battle>
+ */
+class BattleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $trainer1 = Trainer::factory()->create();
+        $trainer2 = Trainer::factory()->create();
+        $winner = fake()->boolean() ? $trainer1->id : $trainer2->id;
+        
+        return [
+            'trainer1_id' => $trainer1->id,
+            'trainer2_id' => $trainer2->id,
+            'winner_id' => fake()->boolean(80) ? $winner : null, // 80% chance of having a winner, 20% chance of a draw
+            'date' => fake()->dateTimeBetween('-1 year', 'now'),
+        ];
+    }
+
+    /**
+     * Indicate that the battle is a draw.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function draw()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'winner_id' => null,
+            ];
+        });
+    }
+}

--- a/database/factories/PokemonFactory.php
+++ b/database/factories/PokemonFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Trainer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Pokemon>
+ */
+class PokemonFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $types = ['Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Ice', 'Dragon', 'Dark', 'Fairy'];
+        
+        return [
+            'name' => fake()->unique()->word(),
+            'type' => fake()->randomElement($types),
+            'level' => fake()->numberBetween(1, 100),
+            'stats' => json_encode([
+                'hp' => fake()->numberBetween(1, 255),
+                'attack' => fake()->numberBetween(1, 255),
+                'defense' => fake()->numberBetween(1, 255),
+                'special_attack' => fake()->numberBetween(1, 255),
+                'special_defense' => fake()->numberBetween(1, 255),
+                'speed' => fake()->numberBetween(1, 255),
+            ]),
+            'trainer_id' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the Pokemon has a trainer.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function withTrainer()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'trainer_id' => Trainer::factory(),
+            ];
+        });
+    }
+}

--- a/database/factories/TrainerFactory.php
+++ b/database/factories/TrainerFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Trainer>
+ */
+class TrainerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->name(),
+            'points' => fake()->numberBetween(0, 1000),
+        ];
+    }
+}

--- a/database/migrations/2025_04_06_095224_create_permission_tables.php
+++ b/database/migrations/2025_04_06_095224_create_permission_tables.php
@@ -1,0 +1,140 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if ($teams && empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/database/migrations/2025_04_06_101633_create_trainers_table.php
+++ b/database/migrations/2025_04_06_101633_create_trainers_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('trainers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->integer('points')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('trainers');
+    }
+};

--- a/database/migrations/2025_04_06_102257_create_pokemons_table.php
+++ b/database/migrations/2025_04_06_102257_create_pokemons_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pokemons', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('type');
+            $table->integer('level');
+            $table->json('stats');
+            $table->foreignId('trainer_id')->nullable()->constrained()->onDelete('set null');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pokemons');
+    }
+};

--- a/database/migrations/2025_04_06_103216_create_battles_table.php
+++ b/database/migrations/2025_04_06_103216_create_battles_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('battles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trainer1_id')->constrained('trainers')->onDelete('cascade');
+            $table->foreignId('trainer2_id')->constrained('trainers')->onDelete('cascade');
+            $table->foreignId('winner_id')->nullable()->constrained('trainers')->onDelete('set null');
+            $table->datetime('date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('battles');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            RoleSeeder::class,
         ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reset cached roles and permissions
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // Create permissions
+        $permissions = [
+            'trainers.view',
+            'trainers.create',
+            'trainers.update',
+            'trainers.delete',
+            'pokemons.view',
+            'pokemons.create',
+            'pokemons.update',
+            'pokemons.delete',
+            'battles.view',
+            'battles.create',
+            'battles.delete'
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::create(['name' => $permission]);
+        }
+        
+        // Admin role
+        $adminRole = Role::create(['name' => 'admin']);
+        $adminRole->givePermissionTo(Permission::all());
+
+        // Trainer role
+        $trainerRole = Role::create(['name' => 'trainer']);
+        $trainerRole->givePermissionTo([
+            'trainers.view',
+            'pokemons.view',
+            'pokemons.update',
+            'battles.view',
+            'battles.create'
+        ]);
+
+        // Guest role
+        $guestRole = Role::create(['name' => 'guest']);
+        $guestRole->givePermissionTo([
+            'trainers.view',
+            'pokemons.view',
+            'battles.view'
+        ]);
+    }
+}

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -43,4 +43,19 @@ class BattleTest extends TestCase{
         $this->assertInstanceOf(Trainer::class, $battle->winner);
         $this->assertEquals($trainer1->id, $battle->winner->id);
     }
+
+    /** @test */
+    public function testBattleCanBeADraw(){
+
+        $trainer1 = Trainer::factory()->create();
+        $trainer2 = Trainer::factory()->create();
+
+        $battle = Battle::factory()->create([
+            'trainer1_id' => $trainer1->id,
+            'trainer2_id' => $trainer2->id,
+            'winner_id' => null
+        ]);
+
+        $this->assertNull($battle->winner);
+    }
 }

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -58,4 +58,14 @@ class BattleTest extends TestCase{
 
         $this->assertNull($battle->winner);
     }
+
+    /** @test */
+    public function testBattleHasDate(){
+
+        $battle = Battle::factory()->create([
+            'date' => '2023-04-02 10:00:00'
+        ]);
+
+        $this->assertEquals('2023-04-02 10:00:00', $battle->date);
+    }
 }

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Battle;
+use App\Models\Trainer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BattleTest extends TestCase{
+
+    use RefreshDatabase;
+
+    /** @test */
+    public function testBattleBelongsToTwoTrainers(){
+
+        $trainer1 = Trainer::factory()->create();
+        $trainer2 = Trainer::factory()->create();
+
+        $battle = Battle::factory()->create([
+            'trainer1_id' => $trainer1->id,
+            'trainer2_id' => $trainer2->id
+        ]);
+
+        $this->assertInstanceOf(Trainer::class, $battle->trainer1);
+        $this->assertInstanceOf(Trainer::class, $battle->trainer2);
+        $this->assertEquals($trainer1->id, $battle->trainer1->id);
+        $this->assertEquals($trainer2->id, $battle->trainer2->id);
+    }
+}

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -27,4 +27,20 @@ class BattleTest extends TestCase{
         $this->assertEquals($trainer1->id, $battle->trainer1->id);
         $this->assertEquals($trainer2->id, $battle->trainer2->id);
     }
+
+    /** @test */
+    public function testBattleHasWinner(){
+
+        $trainer1 = Trainer::factory()->create();
+        $trainer2 = Trainer::factory()->create();
+
+        $battle = Battle::factory()->create([
+            'trainer1_id' => $trainer1->id,
+            'trainer2_id' => $trainer2->id,
+            'winner_id' => $trainer1->id
+        ]);
+
+        $this->assertInstanceOf(Trainer::class, $battle->winner);
+        $this->assertEquals($trainer1->id, $battle->winner->id);
+    }
 }

--- a/tests/Unit/PokemonTest.php
+++ b/tests/Unit/PokemonTest.php
@@ -1,48 +1,50 @@
-<?php 
+<?php
 
 namespace Tests\Unit;
 
 use App\Models\Pokemon;
-Use App\Models\Trainer;
+use App\Models\Trainer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class PokemonTest extends TestCase{
-
+class PokemonTest extends TestCase
+{
     use RefreshDatabase;
 
     /** @test */
-    public function testPokemonBelongsToTrainer(){
-
+    public function testPokemonCanBelongToTrainer()
+    {
         $trainer = Trainer::factory()->create();
         $pokemon = Pokemon::factory()->create(['trainer_id' => $trainer->id]);
-
+        
         $this->assertInstanceOf(Trainer::class, $pokemon->trainer);
         $this->assertEquals($trainer->id, $pokemon->trainer->id);
     }
 
     /** @test */
-    public function testPokemonCanExistsWithoutTrainer(){
-
+    public function testPokemonCanExistWithoutTrainer()
+    {
         $pokemon = Pokemon::factory()->create(['trainer_id' => null]);
-
+        
         $this->assertNull($pokemon->trainer);
     }
 
     /** @test */
-    public function testPokemonHasStats(){
-
+    public function testPokemonHasStats()
+    {
         $stats = [
-            'hp' => 50,
-            'attack' => 55,
-            'defense' => 40,
-            'special_attack' => 50,
-            'special_defense' => 50,
-            'speed' => 55
+            'hp' => 45,
+            'attack' => 49,
+            'defense' => 49,
+            'special_attack' => 65,
+            'special_defense' => 65,
+            'speed' => 45
         ];
-
-        $pokemon = Pokemon::factory()->create(['stats' => json_encode($stats)]);
-
+        
+        $pokemon = Pokemon::factory()->create([
+            'stats' => json_encode($stats)
+        ]);
+        
         $this->assertEquals($stats, json_decode($pokemon->stats, true));
     }
 }

--- a/tests/Unit/PokemonTest.php
+++ b/tests/Unit/PokemonTest.php
@@ -20,4 +20,14 @@ class PokemonTest extends TestCase{
         $this->assertInstanceOf(Trainer::class, $pokemon->trainer);
         $this->assertEquals($trainer->id, $pokemon->trainer->id);
     }
+
+    /** @test */
+    public function testPokemonCanExistsWithoutTrainer(){
+
+        $pokemon = Pokemon::factory()->create(['trainer_id' => null]);
+
+        $this->assertNull($pokemon->trainer);
+    }
+
+    /** @test */
 }

--- a/tests/Unit/PokemonTest.php
+++ b/tests/Unit/PokemonTest.php
@@ -1,0 +1,23 @@
+<?php 
+
+namespace Tests\Unit;
+
+use App\Models\Pokemon;
+Use App\Models\Trainer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PokemonTest extends TestCase{
+
+    use RefreshDatabase;
+
+    /** @test */
+    public function testPokemonBelongsToTrainer(){
+
+        $trainer = Trainer::factory()->create();
+        $pokemon = Pokemon::factory()->create(['trainer_id' => $trainer->id]);
+
+        $this->assertInstanceOf(Trainer::class, $pokemon->trainer);
+        $this->assertEquals($trainer->id, $pokemon->trainer->id);
+    }
+}

--- a/tests/Unit/PokemonTest.php
+++ b/tests/Unit/PokemonTest.php
@@ -30,4 +30,19 @@ class PokemonTest extends TestCase{
     }
 
     /** @test */
+    public function testPokemonHasStats(){
+
+        $stats = [
+            'hp' => 50,
+            'attack' => 55,
+            'defense' => 40,
+            'special_attack' => 50,
+            'special_defense' => 50,
+            'speed' => 55
+        ];
+
+        $pokemon = Pokemon::factory()->create(['stats' => json_encode($stats)]);
+
+        $this->assertEquals($stats, json_decode($pokemon->stats, true));
+    }
 }

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -13,13 +13,26 @@ class TrainerTest extends TestCase{
 
     use RefreshDatabase;
 
-     /** @test */
-     public function testTrainerBelongsToUser()
+    /** @test */
+    public function testTrainerBelongsToUser()
      {
-         $user = User::factory()->create();
-         $trainer = Trainer::factory()->create(['user_id' => $user->id]);
+        $user = User::factory()->create();
+        $trainer = Trainer::factory()->create(['user_id' => $user->id]);
          
-         $this->assertInstanceOf(User::class, $trainer->user);
-         $this->assertEquals($user->id, $trainer->user->id);
+        $this->assertInstanceOf(User::class, $trainer->user);
+        $this->assertEquals($user->id, $trainer->user->id);
      }
+
+    /** @test */
+    public function testTrainerCanHavePokemons(){
+
+        $trainer = Trainer::factory()->create();
+        $pokemon1 = Pokemon::factory()->create(['trainer_id' =>$trainer->id]);
+        $pokemon2 = POkemon::factory()->create(['trainer_id' =>$trainer->id]);
+
+        $this->assertInstanceOf(Pokemon::class, $trainer->pokemons->first());
+        $this->assertCount(2, $trainer->pokemons);
+     }
+    
+    
 }

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -9,64 +9,64 @@ use App\Models\Battle;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class TrainerTest extends TestCase{
-
+class TrainerTest extends TestCase
+{
     use RefreshDatabase;
 
     /** @test */
     public function testTrainerBelongsToUser()
-     {
+    {
         $user = User::factory()->create();
         $trainer = Trainer::factory()->create(['user_id' => $user->id]);
-         
+        
         $this->assertInstanceOf(User::class, $trainer->user);
         $this->assertEquals($user->id, $trainer->user->id);
-     }
+    }
 
     /** @test */
-    public function testTrainerCanHavePokemons(){
-
+    public function testTrainerCanHavePokemons()
+    {
         $trainer = Trainer::factory()->create();
-        $pokemon1 = Pokemon::factory()->create(['trainer_id' =>$trainer->id]);
-        $pokemon2 = POkemon::factory()->create(['trainer_id' =>$trainer->id]);
-
+        $pokemon1 = Pokemon::factory()->create(['trainer_id' => $trainer->id]);
+        $pokemon2 = Pokemon::factory()->create(['trainer_id' => $trainer->id]);
+        
         $this->assertInstanceOf(Pokemon::class, $trainer->pokemons->first());
         $this->assertCount(2, $trainer->pokemons);
-     }
+    }
     
     /** @test */
-    public function testTrainerCanHaveMaximumOfThreePokemons(){
-
+    public function testTrainerCanHaveMaximumOfThreePokemons()
+    {
         $trainer = Trainer::factory()->create();
-
+        
         // Add 3 pokemons (maximum allowed)
         Pokemon::factory()->count(3)->create(['trainer_id' => $trainer->id]);
-
+        
         $this->assertCount(3, $trainer->pokemons);
-        $this->assertTrue($trainer->canAddMorePOkemons() === false);
-
-        //Try to add a 4th pokemon
+        $this->assertTrue($trainer->canAddMorePokemons() === false);
+        
+        // Try to add a 4th pokemon
         $extraPokemon = Pokemon::factory()->create();
         $result = $trainer->addPokemon($extraPokemon);
-
-        //Should fail and not be added
+        
+        // Should fail and not be added
         $this->assertFalse($result);
         $this->assertCount(3, $trainer->fresh()->pokemons);
     }
 
     /** @test */
-    public function testTrainerCanParticipateInBattles(){
-
+    public function testTrainerCanParticipateInBattles()
+    {
         $trainer1 = Trainer::factory()->create();
         $trainer2 = Trainer::factory()->create();
-
-        $batlle = Battle::factory()->create([
+        
+        $battle = Battle::factory()->create([
             'trainer1_id' => $trainer1->id,
             'trainer2_id' => $trainer2->id,
         ]);
-
-        $this->assertInstanceOf(Battle::class, $trainer1->battleAsTrainer1->first());
-        $this->assertInstanceOf(Battle::class, $trainer2->battleAsTrainer2->first());
+        
+        $this->assertInstanceOf(Battle::class, $trainer1->battlesAsTrainer1->first());
+        $this->assertInstanceOf(Battle::class, $trainer2->battlesAsTrainer2->first());
         $this->assertCount(1, $trainer1->battles());
         $this->assertCount(1, $trainer2->battles());
     }

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -34,5 +34,23 @@ class TrainerTest extends TestCase{
         $this->assertCount(2, $trainer->pokemons);
      }
     
-    
+    /** @test */
+    public function testTrainerCanHaveMaximumOfThreePokemons(){
+
+        $trainer = Trainer::factory()->create();
+
+        // Add 3 pokemons (maximum allowed)
+        Pokemon::factory()->count(3)->create(['trainer_id' => $trainer->id]);
+
+        $this->assertCount(3, $trainer->pokemons);
+        $this->assertTrue($trainer->canAddMorePOkemons() === false);
+
+        //Try to add a 4th pokemon
+        $extraPokemon = Pokemon::factory()->create();
+        $result = $trainer->addPokemon($extraPokemon);
+
+        //Should fail and not be added
+        $this->assertFalse($result);
+        $this->assertCount(3, $trainer->fresh()->pokemons);
+    }
 }

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -53,4 +53,21 @@ class TrainerTest extends TestCase{
         $this->assertFalse($result);
         $this->assertCount(3, $trainer->fresh()->pokemons);
     }
+
+    /** @test */
+    public function testTrainerCanParticipateInBattles(){
+
+        $trainer1 = Trainer::factory()->create();
+        $trainer2 = Trainer::factory()->create();
+
+        $batlle = Battle::factory()->create([
+            'trainer1_id' => $trainer1->id,
+            'trainer2_id' => $trainer2->id,
+        ]);
+
+        $this->assertInstanceOf(Battle::class, $trainer1->battleAsTrainer1->first());
+        $this->assertInstanceOf(Battle::class, $trainer2->battleAsTrainer2->first());
+        $this->assertCount(1, $trainer1->battles());
+        $this->assertCount(1, $trainer2->battles());
+    }
 }

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Models\Trainer;
+use App\Models\Pokemon;
+use App\Models\Battle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TrainerTest extends TestCase{
+
+    use RefreshDatabase;
+
+     /** @test */
+     public function testTrainerBelongsToUser()
+     {
+         $user = User::factory()->create();
+         $trainer = Trainer::factory()->create(['user_id' => $user->id]);
+         
+         $this->assertInstanceOf(User::class, $trainer->user);
+         $this->assertEquals($user->id, $trainer->user->id);
+     }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -37,6 +37,17 @@ class UserTest extends TestCase{
     /** @test */
     public function testAdminUserCanExistWithoutTrainer(){
 
+        Role::create(['name' =>'admin']);
+        Role::create(['name' => 'trainer']);
 
+        $adminUser = User::factory()->create();
+        $adminUser->assignRole('admin');
+
+        $trainerUser = User::factory()->create();
+        $trainerUser->assignRole('trainer');
+        Trainer::factory()->create(['user_id' => $trainerUser->id]);
+
+        $this->assertNull($adminUser->trainer);
+        $this->assertInstanceOf(Trainer::class, $trainerUser->trainer);
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,25 @@
+<?php 
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Models\Trainer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Schema;
+
+class UserTest extends TestCase{
+
+    use RefreshDatabase;
+
+    /** @test */
+    public function testUserCanHaveATrainer(){
+
+        $user = User::factory()->create();
+        $trainer = Trainer::factory()->create(['user_id' => $user->id]);
+
+        $this->assertInstanceOf(Trainer::class, $user->trainer);
+        $this->assertEquals($trainer->id, $user->trainer->id);
+    }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -22,4 +22,21 @@ class UserTest extends TestCase{
         $this->assertInstanceOf(Trainer::class, $user->trainer);
         $this->assertEquals($trainer->id, $user->trainer->id);
     }
+
+    /** @test */
+    public function testUserCanHaveRoles(){
+
+        Role::create(['name' => 'admin']);
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+
+        $this->assertTrue($user->hasRole('admin'));
+
+    }
+
+    /** @test */
+    public function testAdminUserCanExistWithoutTrainer(){
+
+
+    }
 }


### PR DESCRIPTION
This Pull Request completes Database Migration and Models by implementing:

- Migrations for all tables:
users (existing table, added support for relationships)
trainers (with limit of 3 Pokémon per trainer)
pokemons
battles
Permission tables (Spatie Permission)


- Models with relationships:
User: with Trainer relationship and Spatie Permission integration
Trainer: with relationships to User, Pokémon, and Battles
Pokemon: with Trainer relationship and limit validation
Battle: with relationships to trainers and winner


- Factories for testing:
TrainerFactory
PokemonFactory
BattleFactory


- Unit tests:
Tests for all model relationships
Business rule validation (limit of 3 Pokémon per trainer)
User role verification (admin vs. trainer)


- Role configuration:
Seeders for roles and permissions according to specification

This implementation completes the database required for the Pokémon League API according to the project specifications, including validation that a trainer cannot have more than 3 Pokémon.
All tests have been implemented following a TDD approach and pass successfully.