### PR TITLE
fix: Update PHPUnit Annotations in Unit and API Tests

### DIFF
--- a/tests/Feature/API/AuthTest.php
+++ b/tests/Feature/API/AuthTest.php
@@ -78,7 +78,6 @@ class AuthTest extends TestCase
         });
     }
 
-    /** @test */
     public function a_user_can_register()
     {
         $response = $this->postJson('/api/register', [
@@ -117,7 +116,6 @@ class AuthTest extends TestCase
         ]);
     }
 
-    /** @test */
     public function a_user_cannot_register_with_invalid_data()
     {
         $response = $this->postJson('/api/register', [
@@ -131,7 +129,6 @@ class AuthTest extends TestCase
                  ->assertJsonValidationErrors(['name', 'email', 'password']);
     }
 
-    /** @test */
     public function a_user_can_login()
     {
         $user = User::factory()->create([
@@ -166,7 +163,6 @@ class AuthTest extends TestCase
                  ]);
     }
 
-    /** @test */
     public function a_user_cannot_login_with_invalid_credentials()
     {
         $user = User::factory()->create([
@@ -185,7 +181,6 @@ class AuthTest extends TestCase
                  ]);
     }
 
-    /** @test */
     public function a_user_can_logout()
     {
         $user = User::factory()->create();
@@ -201,7 +196,6 @@ class AuthTest extends TestCase
                  ]);
     }
     
-    /** @test */
     public function admin_registration_does_not_create_trainer()
     {
         // Admin via direct registration
@@ -224,7 +218,6 @@ class AuthTest extends TestCase
         ]);
     }
     
-    /** @test */
     public function trainer_role_has_necessary_permissions()
     {
         $user = User::factory()->create();

--- a/tests/Feature/API/AuthTest.php
+++ b/tests/Feature/API/AuthTest.php
@@ -78,7 +78,7 @@ class AuthTest extends TestCase
         });
     }
 
-    public function a_user_can_register()
+    public function test_a_user_can_register()
     {
         $response = $this->postJson('/api/register', [
             'name' => 'Test User',
@@ -116,7 +116,7 @@ class AuthTest extends TestCase
         ]);
     }
 
-    public function a_user_cannot_register_with_invalid_data()
+    public function test_a_user_cannot_register_with_invalid_data()
     {
         $response = $this->postJson('/api/register', [
             'name' => '',
@@ -129,7 +129,7 @@ class AuthTest extends TestCase
                  ->assertJsonValidationErrors(['name', 'email', 'password']);
     }
 
-    public function a_user_can_login()
+    public function test_a_user_can_login()
     {
         $user = User::factory()->create([
             'email' => 'test@example.com',
@@ -163,7 +163,7 @@ class AuthTest extends TestCase
                  ]);
     }
 
-    public function a_user_cannot_login_with_invalid_credentials()
+    public function test_a_user_cannot_login_with_invalid_credentials()
     {
         $user = User::factory()->create([
             'email' => 'test@example.com',
@@ -181,7 +181,7 @@ class AuthTest extends TestCase
                  ]);
     }
 
-    public function a_user_can_logout()
+    public function test_a_user_can_logout()
     {
         $user = User::factory()->create();
         $user->assignRole('trainer');
@@ -196,7 +196,7 @@ class AuthTest extends TestCase
                  ]);
     }
     
-    public function admin_registration_does_not_create_trainer()
+    public function test_admin_registration_does_not_create_trainer()
     {
         // Admin via direct registration
         $response = $this->postJson('/api/register', [
@@ -218,7 +218,7 @@ class AuthTest extends TestCase
         ]);
     }
     
-    public function trainer_role_has_necessary_permissions()
+    public function test_trainer_role_has_necessary_permissions()
     {
         $user = User::factory()->create();
         $user->assignRole('trainer');

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -11,7 +11,6 @@ class BattleTest extends TestCase{
 
     use RefreshDatabase;
 
-    /** @test */
     public function testBattleBelongsToTwoTrainers(){
 
         $trainer1 = Trainer::factory()->create();
@@ -28,7 +27,6 @@ class BattleTest extends TestCase{
         $this->assertEquals($trainer2->id, $battle->trainer2->id);
     }
 
-    /** @test */
     public function testBattleHasWinner(){
 
         $trainer1 = Trainer::factory()->create();
@@ -44,7 +42,6 @@ class BattleTest extends TestCase{
         $this->assertEquals($trainer1->id, $battle->winner->id);
     }
 
-    /** @test */
     public function testBattleCanBeADraw(){
 
         $trainer1 = Trainer::factory()->create();

--- a/tests/Unit/BattleTest.php
+++ b/tests/Unit/BattleTest.php
@@ -56,7 +56,6 @@ class BattleTest extends TestCase{
         $this->assertNull($battle->winner);
     }
 
-    /** @test */
     public function testBattleHasDate(){
 
         $battle = Battle::factory()->create([

--- a/tests/Unit/PokemonTest.php
+++ b/tests/Unit/PokemonTest.php
@@ -11,7 +11,6 @@ class PokemonTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
     public function testPokemonCanBelongToTrainer()
     {
         $trainer = Trainer::factory()->create();
@@ -21,7 +20,6 @@ class PokemonTest extends TestCase
         $this->assertEquals($trainer->id, $pokemon->trainer->id);
     }
 
-    /** @test */
     public function testPokemonCanExistWithoutTrainer()
     {
         $pokemon = Pokemon::factory()->create(['trainer_id' => null]);
@@ -29,7 +27,6 @@ class PokemonTest extends TestCase
         $this->assertNull($pokemon->trainer);
     }
 
-    /** @test */
     public function testPokemonHasStats()
     {
         $stats = [

--- a/tests/Unit/TrainerTest.php
+++ b/tests/Unit/TrainerTest.php
@@ -13,7 +13,6 @@ class TrainerTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
     public function testTrainerBelongsToUser()
     {
         $user = User::factory()->create();
@@ -23,7 +22,6 @@ class TrainerTest extends TestCase
         $this->assertEquals($user->id, $trainer->user->id);
     }
 
-    /** @test */
     public function testTrainerCanHavePokemons()
     {
         $trainer = Trainer::factory()->create();
@@ -34,7 +32,6 @@ class TrainerTest extends TestCase
         $this->assertCount(2, $trainer->pokemons);
     }
     
-    /** @test */
     public function testTrainerCanHaveMaximumOfThreePokemons()
     {
         $trainer = Trainer::factory()->create();
@@ -54,7 +51,6 @@ class TrainerTest extends TestCase
         $this->assertCount(3, $trainer->fresh()->pokemons);
     }
 
-    /** @test */
     public function testTrainerCanParticipateInBattles()
     {
         $trainer1 = Trainer::factory()->create();

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -13,7 +13,7 @@ class UserTest extends TestCase{
 
     use RefreshDatabase;
 
-    /** @test */
+    
     public function testUserCanHaveATrainer(){
 
         $user = User::factory()->create();
@@ -23,7 +23,7 @@ class UserTest extends TestCase{
         $this->assertEquals($trainer->id, $user->trainer->id);
     }
 
-    /** @test */
+    
     public function testUserCanHaveRoles(){
 
         Role::create(['name' => 'admin']);
@@ -34,7 +34,6 @@ class UserTest extends TestCase{
 
     }
 
-    /** @test */
     public function testAdminUserCanExistWithoutTrainer(){
 
         Role::create(['name' =>'admin']);


### PR DESCRIPTION
## Overview
This pull request updates PHPUnit annotations across our unit and API tests to resolve warning messages and improve test suite compatibility.

## Changes Implemented
- Reviewed and updated PHPUnit annotations in:
  - Unit tests
  - Feature/API tests
- Resolved deprecation warnings
- Ensured test suite compatibility with latest PHPUnit standards

## Motivation
- Eliminate unnecessary warning messages during test execution
- Maintain clean and modern test code
- Improve overall test suite readability and maintainability

## Testing
- Verified all tests pass without warnings
- Confirmed no changes to test logic or functionality
- Ran full test suite to ensure no regressions

## Scope of Changes
- Updated test method annotations
- Removed or replaced deprecated annotation styles
- Ensured consistent annotation formatting across test files